### PR TITLE
fix: #9 wrong excess dependency if child name contains parent name

### DIFF
--- a/annotation-processor/src/main/java/io/dragee/processor/DrageeElement.java
+++ b/annotation-processor/src/main/java/io/dragee/processor/DrageeElement.java
@@ -106,13 +106,16 @@ record DrageeElement(Element element, DrageeProfile profile) {
     }
 
     private interface HasType {
-
         String type();
 
-        default boolean isOrGeneric(DrageeElement element) {
-            return type().contains(element.name());
+        private boolean isGenericOf(String type, String elementName) {
+            String regex = ".*<\\s*([^,>]*,\\s*)*" + elementName + "(\\s*,[^,>]*)*>.*";
+            return type.matches(regex);
         }
 
+        default boolean isOrGeneric(DrageeElement element) {
+            return element.name().equals(type()) || isGenericOf(type(), element.name());
+        }
     }
 
     record Constructor(List<Parameter> parameters) {
@@ -140,12 +143,14 @@ record DrageeElement(Element element, DrageeProfile profile) {
             return new Parameter(type, name);
         }
     }
+
     record Return(String type) implements HasType {
 
         public static Return ofType(String type) {
             return new Return(type);
         }
     }
+
     record Method(String name, boolean isPrivate, List<Parameter> parameters, Return returnType) {
 
         public boolean use(DrageeElement otherElement) {

--- a/annotation-processor/src/test/java/io/dragee/rules/fixes/issue9/MethodReturnExcessDependencyTest.java
+++ b/annotation-processor/src/test/java/io/dragee/rules/fixes/issue9/MethodReturnExcessDependencyTest.java
@@ -1,0 +1,46 @@
+package io.dragee.rules.fixes.issue9;
+
+import io.dragee.testing.Compiler;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+class MethodReturnExcessDependencyTest {
+
+    private static final Path SOURCE_FOLDER = Path.of("io", "dragee", "rules", "fixes", "issue9");
+    private static final Path OUTPUT_FOLDER = Path.of("io", "dragee", "rules", "fixes", "issue9");
+
+    private static Compiler.Result executeProcessor() {
+        Compiler compiler = Compiler.compileTestClasses(
+                SOURCE_FOLDER.resolve("Test.java"),
+                SOURCE_FOLDER.resolve("TestId.java")
+        );
+
+        return compiler.executeProcessor();
+    }
+
+    private static String contentOfChildDragee(Compiler.Result actualResult) {
+        return actualResult.readDrageeFile(OUTPUT_FOLDER.resolve("TestId.json"));
+    }
+
+    /**
+     * Issue #9 : <a href="https://github.com/dragee-io/dragee-java-processor/issues/9">...</a>
+     * Test has a dependency to TestId.
+     * TestId was wrongfully stating that it had a dependency to Test.
+     * This was due to a bad HasType.isOrGeneric, based on a simple contains.
+     */
+    @Test
+    void dragee_child_must_not_have_parent_on_dependency_when_name_contains_parent_name() {
+        Compiler.Result actualResult = executeProcessor();
+
+        String actualChildContent = contentOfChildDragee(actualResult);
+
+        assertThatJson(actualChildContent)
+                .inPath("$.depends_on")
+                .isObject()
+                .containsOnlyKeys(
+                        "io.dragee.rules.fixes.issue9.TestId");
+    }
+}

--- a/annotation-processor/src/test/java/io/dragee/rules/fixes/issue9/Namespace.java
+++ b/annotation-processor/src/test/java/io/dragee/rules/fixes/issue9/Namespace.java
@@ -1,0 +1,29 @@
+package io.dragee.rules.fixes.issue9;
+
+import io.dragee.annotation.Dragee;
+
+import java.lang.annotation.*;
+
+@Dragee.Namespace
+@Inherited
+@Documented
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@interface Namespace {
+
+    @Namespace
+    @Documented
+    @Inherited
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ParentType {
+    }
+
+    @Namespace
+    @Documented
+    @Inherited
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ChildType {
+    }
+}

--- a/annotation-processor/src/test/java/io/dragee/rules/fixes/issue9/Test.java
+++ b/annotation-processor/src/test/java/io/dragee/rules/fixes/issue9/Test.java
@@ -1,0 +1,15 @@
+package io.dragee.rules.fixes.issue9;
+
+@Namespace.ParentType
+record Test(TestId id) {
+
+    Test {
+        if (id == null) {
+            throw new IllegalArgumentException("id cannot be null");
+        }
+    }
+
+    boolean hasId(TestId id) {
+        return this.id.equals(id);
+    }
+}

--- a/annotation-processor/src/test/java/io/dragee/rules/fixes/issue9/TestId.java
+++ b/annotation-processor/src/test/java/io/dragee/rules/fixes/issue9/TestId.java
@@ -1,0 +1,15 @@
+package io.dragee.rules.fixes.issue9;
+
+import java.util.UUID;
+
+@Namespace.ChildType
+record TestId(String value) {
+
+    static TestId of(String value) {
+        return new TestId(value);
+    }
+
+    static TestId generate() {
+        return new TestId(UUID.randomUUID().toString());
+    }
+}


### PR DESCRIPTION
Test has a dependency to TestId.
TestId was wrongfully stating that it had a dependency to Test. This was due to a bad `HasType.isOrGeneric`, based on a simple contains.